### PR TITLE
Add support for boot on EFI machines.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@ RUN . ./variables.sh && \
     rm -f /etc/apt/sources.list && \
     echo "deb http://snapshot.debian.org/archive/debian/$(date --date "$DATE" '+%Y%m%dT%H%M%SZ') $DIST main" >> /etc/apt/sources.list && \
     echo "deb http://snapshot.debian.org/archive/debian/$(date --date "$DATE" '+%Y%m%dT%H%M%SZ') "$DIST"-updates main" >> /etc/apt/sources.list && \
-    echo "deb http://snapshot.debian.org/archive/debian-security/$(date --date "$DATE" '+%Y%m%dT%H%M%SZ') "$DIST"/updates main" >> /etc/apt/sources.list
+    echo "deb http://snapshot.debian.org/archive/debian-security/$(date --date "$DATE" '+%Y%m%dT%H%M%SZ') "$DIST"/updates main" >> /etc/apt/sources.list && \
+    echo "APT::Default-Release \"$DIST\";" > /etc/apt/apt.conf && \
+    echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
 
 RUN apt-get update -o Acquire::Check-Valid-Until=false && \
     apt-get install -o Acquire::Check-Valid-Until=false --no-install-recommends --yes \
+    grub-pc-bin grub-efi-ia32-bin grub-efi-amd64-bin mtools=4.0.18-2.1 \
     liblzo2-2 xorriso debootstrap \
     locales && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RELEASE = 0.4.0
+RELEASE = 0.4.1
 
 .PHONY: usage build remove run copy all default
 

--- a/SHA256SUMS
+++ b/SHA256SUMS
@@ -1,4 +1,4 @@
-f9fd8d851d5a855cfa97eafe062418fb97e9cb574bab77326e9a34f9e8aa2c98  ./create-iso.sh
+e621b4d47321a0117d5950501324a472dc141d333f651b3f0c6c778998468a7c  ./create-iso.sh
 c93b498e8599dd2368ae92622aee2342a312f84ae216eb2ece659fa9e4864ca3  ./tools/debuerreotype_0.7-1_all.deb
 dbed950a8b2e9c35dd76002e414268697a4b84749625753266c13bfbfa5eccb8  ./tools/hooks/00-install-ksk-packages.sh
 fa97bedd94635866336547f7f5c2aaeff10e8533ed86e4819d3820d8ccb1c862  ./tools/hooks/01-fix-fontconfig-cache.sh
@@ -21,4 +21,4 @@ a8946b779ccf305da8dadefa9d7d9402ccfe756246dd70a251e4375076a83648  ./tools/packag
 a0ae2652c5ca8461752f17ab22aa385c588481351b7b4aeb199a3d23d6479c34  ./tools/packages/libgtk2.0-0_2.24.31-2.0tails1_amd64.deb
 0862890d70bafeb6b4a7a1c1da05c90569e0147522d6526fad6d146d6335b79f  ./tools/packages/libgtk2.0-common_2.24.31-2.0tails1_all.deb
 5c7ab880233139bc213d2ef214dc6c433eac488eaa51f8d59c4eb791fa777293  ./tools/squashfs-tools_4.3-3.0tails4_amd64.deb
-eb66b37b4c0a81285e0c2fa18787b942fdee63a4d1c25cb4343ab50c03d1524a  ./variables.sh
+038998484c1424e5f069d08bb6a9cc6f6b0b0686c4230568504308eeff9a2de0  ./variables.sh

--- a/variables.sh
+++ b/variables.sh
@@ -6,11 +6,11 @@ set -x   # Print each command before executing it
 set -e   # Exit immediately should a command fail
 set -u   # Treat unset variables as an error and exit immediately
 
-export RELEASE=0.4.0   # Release version number
+export RELEASE=0.4.1   # Release version number
 export DATE=20180311   # Timestamp to use for version packages (`date +%Y%m%d`)
 export DIST=stretch    # Debian distribution to base image on
 export ARCH=amd64      # Target architecture
-export SHASUM="8105b885b176741d25ef9d391c6a302aed3f6c916093a621a865cb90d560774f  -" # ISO image SHA-256 
+export SHASUM="25b9a774f1bedab7757a4331d84ea980ea37ea7cf99bb4aa3abb79833f081db2  -" # ISO image SHA-256 
 export SOURCE_DATE_EPOCH="$(date --utc --date="$DATE" +%s)" # defined by reproducible-builds.org
 export WD=/opt/coen-${RELEASE}	       # Working directory to create the image
 export ISONAME=${WD}-${ARCH}.iso       # Final name of the ISO image


### PR DESCRIPTION
1. Switch from ISOLINUX to GRUB for bootloader.
- GRUB configuration is derived from original ISOLINUX configuration. 
- Requires mtools release from Debian _testing_ distribution to fix [#900410](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900410)
2. Add GRUB images for Legacy BIOS, 32-bit EFI and 64-bit EFI.
- Successfully boots MacBookAir7,2 from USB using 64-bit EFI. 
- Successfully boots VMWare from ISO file using both Legacy BIOS and 64-bit UEFI. 
3. Parameterize additional instances of ARCH.